### PR TITLE
[Refactor]: 회원탈퇴(본인만)

### DIFF
--- a/src/main/kotlin/org/tenten/bittakotlin/member/controller/MemberController.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/member/controller/MemberController.kt
@@ -2,15 +2,20 @@ package org.tenten.bittakotlin.member.controller
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.*
 import org.tenten.bittakotlin.member.dto.MemberRequestDTO
 import org.tenten.bittakotlin.member.dto.MemberResponseDTO
+import org.tenten.bittakotlin.member.repository.MemberRepository
 import org.tenten.bittakotlin.member.service.MemberService
+import org.tenten.bittakotlin.security.jwt.JWTUtil
 
 @RestController
 @RequestMapping("/api/member")
 class MemberController(
-    private val memberService: MemberService
+    private val memberService: MemberService,
+    private val jwtUtil: JWTUtil,
+    private val memberRepository: MemberRepository
 ) {
 
     // 회원가입
@@ -39,8 +44,14 @@ class MemberController(
     }
 
     @DeleteMapping("/{id}")
-    fun remove(@PathVariable id: Long): ResponseEntity<String> {
-        memberService.remove(id)
-        return ResponseEntity.ok("탈퇴에 성공했습니다.")
+    fun remove(@PathVariable id: Long, @RequestHeader("access") token: String): ResponseEntity<String> {
+        val username = jwtUtil.getUsername(token)
+        val member = memberRepository.findById(id)
+            .orElseThrow { IllegalArgumentException("Member not Found.") }
+        if(member.username != username) {
+            throw AccessDeniedException("You don't have permission to delete this member.")
+        }
+        memberRepository.delete(member)
+        return ResponseEntity.ok("탈퇴 성공")
     }
 }

--- a/src/main/kotlin/org/tenten/bittakotlin/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/security/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import JWTFilter
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -75,6 +76,7 @@ class SecurityConfig(
                     "/api/member/join",
                     "/api/member/reissue").permitAll()
                 .requestMatchers("/api/member/{id}/**").hasRole("USER")
+                .requestMatchers(HttpMethod.DELETE,"/api/member/{id}").authenticated()
                 .anyRequest().authenticated()
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#17 

## ☑️ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더명 수정
- [ ] CSS 등 사용자 UI 디자인 변경


## 📝 작업 내용

- 회원 탈퇴 기능 구현: 사용자 인증 정보를 기반으로 요청한 사용자만 자신의 계정을 삭제할 수 있도록 기능을 추가했습니다. 요청 시 전달된 id와 액세스 토큰의 사용자 이름을 비교하여 일치하는 경우에만 계정을 삭제하도록 예외 처리를 구현했습니다.

## ✅ 피드백 반영사항


## 💬 리뷰 요구사항
<!-- 리뷰어가 중점적으로 봐주면 좋을 것 같은 부분이 있다면 작성해주세요. ->

