### PR TITLE
Refactoring: member 측 매핑 제거

### DIFF
--- a/src/main/kotlin/org/tenten/bittakotlin/member/entity/Member.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/member/entity/Member.kt
@@ -21,11 +21,6 @@ data class Member(
     @OneToOne(mappedBy = "member", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     var profile: Profile? = null,
 
-    @OneToMany(mappedBy = "sender", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val sentScoutRequests: MutableList<ScoutRequest> = mutableListOf(),
-
-    @OneToMany(mappedBy = "receiver", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val receivedScoutRequests: MutableList<ScoutRequest> = mutableListOf(),
 
     @Column(nullable = false, unique = true)
     var username: String = "",

--- a/src/main/kotlin/org/tenten/bittakotlin/scout/repository/ScoutRequestRepository.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/scout/repository/ScoutRequestRepository.kt
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.tenten.bittakotlin.scout.entity.ScoutRequest
 
 interface ScoutRequestRepository : JpaRepository<ScoutRequest, Long> {
-    fun findBySender_IdOrderById(senderId: Long, pageable: Pageable): Page<ScoutRequest>
-    fun findByReceiver_IdOrderById(receiverId: Long, pageable: Pageable): Page<ScoutRequest>
+    fun findBySenderIdOrderById(senderId: Long, pageable: Pageable): Page<ScoutRequest>
+    fun findByReceiverIdOrderById(receiverId: Long, pageable: Pageable): Page<ScoutRequest>
 }

--- a/src/main/kotlin/org/tenten/bittakotlin/scout/service/ScoutRequestService.kt
+++ b/src/main/kotlin/org/tenten/bittakotlin/scout/service/ScoutRequestService.kt
@@ -39,7 +39,7 @@ class ScoutRequestService(
     fun getSentScoutRequests(senderId: Long, pageable: Pageable): Page<ScoutDTO> {
         logger.info("Fetching sent scout requests for senderId=$senderId")
 
-        val sentRequests = scoutRequestRepository.findBySender_IdOrderById(senderId, pageable)
+        val sentRequests = scoutRequestRepository.findBySenderIdOrderById(senderId, pageable)
             .map { request -> entityToDto(request) }
 
         logger.info("Retrieved ${sentRequests.totalElements} sent scout requests for senderId=$senderId")
@@ -50,7 +50,7 @@ class ScoutRequestService(
     fun getReceivedScoutRequests(receiverId: Long, pageable: Pageable): Page<ScoutDTO> {
         logger.info("Fetching received scout requests for receiverId=$receiverId")
 
-        val receivedRequests = scoutRequestRepository.findByReceiver_IdOrderById(receiverId, pageable)
+        val receivedRequests = scoutRequestRepository.findByReceiverIdOrderById(receiverId, pageable)
             .map { request -> entityToDto(request) }
 
         logger.info("Retrieved ${receivedRequests.totalElements} received scout requests for receiverId=$receiverId")


### PR DESCRIPTION
## #️⃣연관된 이슈
<!---- Resolves: #2  -->


## ☑️ PR 유형
- [x] 코드 리팩토링


## 📝 작업 내용
ScoutRequest 은 이제 Profile 과 매핑되기 때문에 member 측 참조를 제거했습니다.
Profile 측에 OneToMany 로 ScoutRequest 매핑관계가 써져 있는데, 실제로 사용하진 않습니다! 참조관계를 표현하기 위해서만 존재하기 때문에 신경쓰지 않으셔도 됩니다!

## ✅ 피드백 반영사항


## 💬 리뷰 요구사항
<!-- 리뷰어가 중점적으로 봐주면 좋을 것 같은 부분이 있다면 작성해주세요. ->

